### PR TITLE
Remove unneeded import

### DIFF
--- a/SynArmorSlotsPatcher/Program.cs
+++ b/SynArmorSlotsPatcher/Program.cs
@@ -4,7 +4,6 @@ using Mutagen.Bethesda.Synthesis;
 using Mutagen.Bethesda.Skyrim;
 using Noggog;
 using SynArmorSlotsPatchers.Settings;
-using Microsoft.Extensions.Logging;
 
 namespace SynArmorSlotsPatchers
 {


### PR DESCRIPTION
When I tried to use the .synth file, or directly reference the main github repo for SynArmorSlotsPatcher, I kept getting the following error in Synthesis:

```
Program.cs(7,17): error CS0234: The type or namespace name 'Extensions' does not exist in the namespace 'Microsoft' (are you missing an assembly reference?)
Program.cs(7,17): error CS0234: The type or namespace name 'Extensions' does not exist in the namespace 'Microsoft' (are you missing an assembly reference?)
```

I was able to fetch the source code, modify it to remove the `using Microsoft.Extensions.Logging` line, and use my local checkout within Synthesis to successfully use the patcher.